### PR TITLE
v/0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
+# 0.3.0
+- Completely rewrote how registered objects are stored and retrieved
+  - Objects are now stored in `registry.Registry._OBJECTS` as a dictionary with the configuration name as the key.
+  - New methods are: `add()`, `find()`, and `remove()`
+  - Stored objects now include keys `category`, `cls`, and `instances`
+- Removed `@register_instance` decorator
+  - `@register_definition` now registers the class and records the instances when `register_instances=True`
+
+
 # 0.2.4
 - `register_definition()` was updated to require the `name: str` parameter 
   - This change was made so that classes could be registered with a name that is different from the class name.
   - We also observed that using `str.lower().title()` was not consistent, so this change means we always know what the class' registered name is will be.
-
 
 # 0.2.3
 - Changed `register_objects()` so that it will scan packages beginning with `CloudHarvest` and not `CloudHarvestPlugin`.

--- a/CloudHarvestCorePluginManager/__init__.py
+++ b/CloudHarvestCorePluginManager/__init__.py
@@ -1,1 +1,0 @@
-from .registry import Registry

--- a/CloudHarvestCorePluginManager/decorators.py
+++ b/CloudHarvestCorePluginManager/decorators.py
@@ -1,61 +1,45 @@
 from .registry import Registry
 
 
-def register_definition(name: str):
+def register_definition(category: str, name: str, register_instances: bool = False):
     """
-    A decorator to register a class in the 'Registry.definitions' when defined.
+    A decorator to register a class in the Registry when it is defined.
 
-    The decorator takes the `name` argument. The `name` arugment is used when searching for classes using the
-    Registery.find_definition() method.
+    :param category: The category of the class. Lowercase is enforced.
+    :param name: The name of the class. Lowercase is enforced.
+    :param register_instances: If True, automatically register instances of the class. It is not necessary to register
+    instances unless the application must later retrieve them, such as CommandSet (CLI) or Blueprint (API) instances.
 
-    The most common scenario for needing this decorator involves Tasks. This way, a Task can be found when planning a
-    TaskChain.
-
-    Args:
-        name (str, optional): The name to use as the key in the `Registry.definitions` dictionary.
-                              If not provided, the class's name is used.
-
-    Example:
-    >>> @register_definition(name='MyNamedClass')
-    >>> class MyClass:
+    Example
+    >>> @register_definition(category='task', name='my_task', register_instances=True)
+    >>> class MyTask:
     >>>     pass
     """
 
     def decorator(cls):
+        """
+        A decorator to register a class in the Registry when it is defined.
+        :param cls: A class
+        :return: The class
+        """
+
         # Add the class to the Registry
-        Registry.definitions[name] = cls
+        Registry.add(name=name, category=category, cls=cls)
+
+        if register_instances:
+            original_init = cls.__init__
+
+            def new_init(self, *args, **kwargs):
+                # Call the original __init__ method
+                original_init(self, *args, **kwargs)
+
+                # Add the instance to the Registry
+                Registry.add(name=name, instances=[self])
+
+            # Replace the class's __init__ method with the new one
+            cls.__init__ = new_init
 
         # Return the class
         return cls
 
     return decorator
-
-
-def register_instance(cls):
-    """
-    A decorator to register an instance in the 'Registry.instances' when its class is instantiated.
-
-    The most common scenario for this decorator is registering Flask Blueprints for the API.
-
-    >>> @register_instance
-    >>> class MyClass:
-    >>>     pass
-    """
-
-    # Save the original __init__ method
-    original_init = cls.__init__
-
-    # Define a new __init__ method
-    def new_init(self, *args, **kwargs):
-        # Call the original __init__ method
-        original_init(self, *args, **kwargs)
-
-        # Register the instance if it does not already exist in the list
-        if self not in Registry.instances:
-            Registry.instances.append(self)
-
-    # Replace the class's __init__ method with the new one
-    cls.__init__ = new_init
-
-    # Return the class
-    return cls

--- a/CloudHarvestCorePluginManager/functions.py
+++ b/CloudHarvestCorePluginManager/functions.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from registry import logger
+
 
 def list_plugins_from_github_organization(organization: str) -> List[str]:
     """
@@ -25,3 +27,33 @@ def list_plugins_from_github_organization(organization: str) -> List[str]:
         ]
 
     return []
+
+
+def register_objects():
+    """
+    Loads all packages with the prefix 'CloudHarvest' and imports the contents of each package's '__register__.py' file.
+    This allows the decorators to register the classes in the Registry.
+    """
+    import pkgutil
+    import importlib
+    import site
+
+    # Get the path of the site-packages directory
+    site_packages_path = site.getsitepackages()[0]
+
+    # Iterate over all modules in the site-packages directory
+    for _, package_name, _ in pkgutil.iter_modules([site_packages_path]):
+
+        # Check if the package name starts with 'CloudHarvest'
+        if package_name.startswith('CloudHarvest'):
+
+            # Try to import the '__register__.py' file from the package
+            try:
+                importlib.import_module(f'{package_name}.__register__')
+
+            except ImportError:
+                # If the '__register__.py' file does not exist, skip this package
+                continue
+
+            else:
+                logger.info(f'Loaded package: {package_name}')

--- a/CloudHarvestCorePluginManager/meta.json
+++ b/CloudHarvestCorePluginManager/meta.json
@@ -7,5 +7,5 @@
     "license": "CC Attribution-NonCommercial-ShareAlike 4.0 International",
     "name": "CloudHarvestCorePluginManager",
     "url": "https://github.com/Cloud-Harvest/CloudHarvestCorePluginManager",
-    "version": "0.2.4"
+    "version": "0.3.0"
 }

--- a/CloudHarvestCorePluginManager/registry.py
+++ b/CloudHarvestCorePluginManager/registry.py
@@ -1,3 +1,42 @@
+"""
+The Registry module is responsible for storing references and instances of different classes and _REGISTRY. In order to
+register an object, it is necessary to take the following steps:
+1. Provide the appropriate @decorator in .decorators in the class definition.
+2. Import all decorated classes into __register.py__ in the package's source code root directory.
+3. Call register_objects() during application load
+
+Registry Structure
+The Registry is a dictionary of dictionaries that stores the following information about each object:
+
+Key         | Default   | Description
+------------|-----------|------------
+name        | None      | The name of the object. This must be a unique identifier. For example, the FileTask is known as 'file'. No other object can have the name 'file'.
+category    | None      | The category of the object.
+cls         | None      | The class of the object.
+instances   | []        | A list of instances of the object.
+
+
+Object Categories
+All registered objects are categorized into one of the following which must be provided in lower case characters:
+
+Category  | Description
+----------|------------
+blueprint | A flask blueprint used to extend the functionality of the API.
+task      | Represents a task that can be executed.
+
+Custom categories can be provided as needed.
+
+Example
+>>> Registry._OBJECTS = {
+>>>     'name': {
+>>>         'category': 'task',
+>>>         'cls': Any,
+>>>         'instances': []
+>>>     }
+>>> }
+
+"""
+
 from logging import getLogger
 from typing import Any, List
 
@@ -5,123 +44,142 @@ logger = getLogger('harvest')
 
 
 class Registry:
-    definitions = {}
-    instances = []
+    """
+    This static class represents the Registry, which is used to store references and instances of different classes and
+    objects. _OBJECTS should not be accessed directly. Instead, use the add(), find(), and remove() methods to interact
+    with the Registry.
+    """
+
+    _OBJECTS = {}
 
     @staticmethod
-    def find_definition(class_name: str = None,
-                        is_instance_of: Any = None,
-                        is_subclass_of: Any = None,
-                        return_all_matching: bool = False) -> List[Any]:
+    def add(name: str, category: str = None, cls: Any = None, instances: List[Any] = None) -> None:
         """
-        Finds and returns classes from the Registry's definitions that match the provided criteria.
+        Adds the provided object to the Registry.
 
-        Args:
-            class_name (str): The name of the class to find.
-            is_instance_of (Any): An instance type that the class should be an instance of.
-            is_subclass_of (Any): A class that the class should be a subclass of.
-            return_all_matching (bool): If True, returns all matching classes. If False, returns only the first matching class.
-
-        Returns:
-            List[Any]: A list of matching classes. If no classes match the criteria, returns an empty list.
+        :param name: The name of the object to add.
+        :param category: The category of the object to add.
+        :param cls: The class of the object to add.
+        :param instances: One or more instantiated objects to add to the Registry.
         """
-        result = []
 
-        # If class_name is provided, retrieve the class based on the key
-        if class_name:
-            cls = Registry.definitions.get(class_name)
-            if cls is None:
-                return result
+        # Check if the object already exists in the Registry
+        if not Registry._OBJECTS.get(name):
+            if not category or not cls:
+                raise ValueError('Category and class must be provided when adding a new object to the Registry.')
+
             else:
-                definitions = {class_name: cls}
-        else:
-            definitions = Registry.definitions
+                # Add the object to the Registry
+                Registry._OBJECTS[name.lower()] = {
+                    'category': category.lower(),
+                    'cls': cls,
+                    'instances': []
+                }
 
-        # Iterate over all classes in the Registry's definitions
-        for name, cls in definitions.items():
+        # If instances are provided, add them to the object's instances list, but only if the object is not already in the
+        # list. This prevents duplicate instances from being added.
+        if instances:
+            [
+                Registry._OBJECTS[name]['instances'].append(instance)
+                for instance in instances
+                if instance not in Registry._OBJECTS[name]['instances']
+            ]
 
-            # Check if the class is an instance of the provided instance type
-            if is_instance_of and not isinstance(cls, is_instance_of):
-                continue
-
-            # Check if the class is a subclass of the provided class
-            if is_subclass_of and not issubclass(cls, is_subclass_of):
-                continue
-
-            # If the class matches all of the criteria, add it to the result list
-            result.append(cls)
-
-            # If return_all_matching is False, stop searching after finding the first matching class
-            if not return_all_matching:
-                break
-
-        return result
+        return None
 
     @staticmethod
-    def find_instance(class_name: str = None,
-                      is_instance_of: Any = None,
-                      is_subclass_of: Any = None,
-                      return_all_matching: bool = False) -> List[Any]:
+    def clear() -> None:
         """
-        Finds and returns instances from the Registry's instances that match the provided criteria.
-
-        Args:
-            class_name (str): The name of the class of the instance to find.
-            is_instance_of (Any): An instance type that the instance should be an instance of.
-            is_subclass_of (Any): A class that the instance's class should be a subclass of.
-            return_all_matching (bool): If True, returns all matching instances. If False, returns only the first matching instance.
-
-        Returns:
-            List[Any]: A list of matching instances. If no instances match the criteria, returns an empty list.
+        Clears the Registry of all objects.
         """
+
+        Registry._OBJECTS.clear()
+
+        return None
+
+    @staticmethod
+    def find(result_key: str, name: str = None, category: str = None, cls: Any = None, limit: int = 1) -> List[Any]:
+        """
+        Finds and returns the result_key based on the provided criteria.
+
+        :param result_key: The key to return.
+        :param name: The name of the object to find.
+        :param category: The category of the object to find.
+        :param cls: The class of the object to find. If provided, the object must be an instance or subclass of this class.
+        :param limit: Maximum matching items to return.
+        :return: The result_key of objects matching the provided criteria.
+
+        Example:
+        >>> # Returns the instances of the class with the name 'my_class'.
+        >>> Registry.find(result_key='instances', name='my_class')
+        >>> [instance1, instance2, ...]
+
+        >>> # Returns the classes of the objects with the category 'task'.
+        >>> Registry.find(result_key='cls', category='task')
+        >>> [class1, class2, ...]
+
+        >>> # Return a class with the name 'my_class' and category 'task'.
+        >>> Registry.find(result_key='cls', name='my_class', category='task', limit=1)
+        >>> [class1]
+        """
+
         result = []
 
-        # Iterate over all instances in the Registry's instances
-        for instance in Registry.instances:
-
-            # Check if the instance's class name matches the provided class name
-            if class_name and instance.__class__.__name__ != class_name:
+        for _name, _config in Registry._OBJECTS.items():
+            if name and name.lower() != _name:
                 continue
 
-            # Check if the instance is an instance of the provided instance type
-            if is_instance_of and not isinstance(instance, is_instance_of):
+            if category and category.lower() != _config['category']:
                 continue
 
-            # Check if the instance's class is a subclass of the provided class
-            if is_subclass_of and not issubclass(instance.__class__, is_subclass_of):
+            if cls and cls is _config['cls']:
                 continue
 
-            # If the instance matches all of the criteria, add it to the result list
-            result.append(instance)
+            if result_key == 'name':
+                result.append(_name)
 
-            # If return_all_matching is False, stop searching after finding the first matching instance
-            if not return_all_matching:
+            else:
+                if _config.get(result_key):
+                    if isinstance(_config[result_key], list):
+                        result.extend(_config[result_key])
+
+                    else:
+                        result.append(_config[result_key])
+
+            if len(result) >= limit:
                 break
 
         return result
 
     @staticmethod
-    def register_objects():
+    def remove(name: str = None, category: str = None, cls: Any = None, instances: List[Any] = None) -> None:
         """
-        Loads all packages with the prefix 'CloudHarvest' and imports the contents of each package's '__register__.py' file.
+        Removes the object with the provided name from the Registry.
+
+        :param name: The configuration name to remove.
+        :param category: The category of the object to remove.
+        :param cls: The class of the object to remove.
+        :param instances: One or more instances of the object to remove.
         """
-        import pkgutil
-        import importlib
-        import site
 
-        # Get the path of the site-packages directory
-        site_packages_path = site.getsitepackages()[0]
+        if name:
+            name = name.lower()
+            if Registry._OBJECTS.get(name):
+                Registry._OBJECTS.pop(name)
 
-        # Iterate over all modules in the site-packages directory
-        for _, package_name, _ in pkgutil.iter_modules([site_packages_path]):
-
-            # Check if the package name starts with 'CloudHarvest'
-            if package_name.startswith('CloudHarvest'):
-
-                # Try to import the '__register__.py' file from the package
-                try:
-                    importlib.import_module(f'{package_name}.__register__')
-
-                except ImportError:
-                    # If the '__register__.py' file does not exist, skip this package
+        if category or cls or instances:
+            for _name in tuple(Registry._OBJECTS.keys()):
+                if category and category.lower() == Registry._OBJECTS[_name]['category']:
+                    Registry._OBJECTS.pop(_name)
                     continue
+
+                if cls and cls is Registry._OBJECTS[_name]['cls']:
+                    Registry._OBJECTS.pop(_name)
+                    continue
+
+                if instances:
+                    for instance in instances:
+                        if instance in Registry._OBJECTS[_name]['instances']:
+                            Registry._OBJECTS[_name]['instances'].remove(instance)
+
+        return None

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ for more information.
 - [How to Implement Your Plugin](#how-to-implement-your-plugin)
   - [Decorators](#decorators)
     - [`register_definition`](#register_definition)
-    - [`register_instance`](#register_instance)
   - [`__registry__.py`](#__registry__py)
 - [License](#license)
 - [Special License Considerations](#special-license-considerations)
@@ -45,8 +44,10 @@ When creating a new `Task` or `TaskChain`, it is recommended to use the followin
     - The same as the class name without the suffix
     - Lowercase
     - With underscores between camel case words
+- Any registered object should being with a short plugin identifier in its name, such as `aws_` or `gcp_`
+  - The exception to this rule is any `Core` component which does not require a prefix.
 
-For example, a class named `MyTask` should be called in a `TaskChain` YAML file as `my`. A practical example of this is `CacheAggregateTask` which is called as `cache_aggregate`.
+For example, a class named `MyTask` should be called in a `TaskChain` YAML file as `my`. If this Task is part of the Aws plugin, it would read `aws_my`.
 
 ### Task Chain YAML
 All TaskChains are defined in YAML files. The following is an example of a TaskChain YAML file:
@@ -95,38 +96,23 @@ such as [CloudHarvestApi](https://github.com/Cloud-Harvest/CloudHarvestApi/blob/
 ```python
 # In this example, we add the MyNewTask class to the Registry.
 from CloudHarvestCoreTasks.base import BaseTask
-from CloudHarvestCorePluginManager.decorators import register_definition, register_instance
+from CloudHarvestCorePluginManager.decorators import register_definition
 
-@register_definition
+@register_definition(category='task', name='my_new_task', register_instances=False)
 class MyNewTask(BaseTask):
   def __init__(self):
     pass
 
 # Elsewhere in the code, use the following to execute your class:
 from CloudHarvestCorePluginManager.registry import Registry
-my_class = Registry.find_definition('MyNewTask')[0](my_arg='my_value')
-```
-
-### `register_instance`
-```python
-# In this example, add instances of a class to the Registry.
-from CloudHarvestCorePluginManager.decorators import register_instance
-@register_instance
-class MyClass:
-    def __init__(self):
-        pass
-
-myclass = MyClass()
+my_class = Registry.find(result_key='cls', name='my_new_task')[0](my_arg='my_value')
 ```
 
 ## `__registry__.py`
 ```python
 # Captures definitions
 from .tasks import MyNewTask, MyOtherNewTask
-
-# Captures instances
 from .blueprints import my_blueprint
-
 ```
 
 # License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+flatten_json
 requests
 setuptools


### PR DESCRIPTION
- Completely rewrote how registered objects are stored and retrieved
  - Objects are now stored in `registry.Registry._OBJECTS` as a dictionary with the configuration name as the key.
  - New methods are: `add()`, `find()`, and `remove()`
  - Stored objects now include keys `category`, `cls`, and `instances`
- Removed `@register_instance` decorator
  - `@register_definition` now registers the class and records the instances when `register_instances=True`
